### PR TITLE
Build only for amd64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,6 +54,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: BUILD_DATE=${{ steps.date.outputs.date }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Because it fails when we are building for multiple platforms (probably because of our firewall update).